### PR TITLE
Show events on the "Overview" page and the "Client" page

### DIFF
--- a/cloud.js
+++ b/cloud.js
@@ -11,3 +11,59 @@ AV.Cloud.beforeSave("_User", request => {
     throw new AV.Cloud.Error("You are not logged in.");
   }
 });
+AV.Cloud.afterSave("Client", request => {
+  const events = [
+    {
+      name: "Welcome Email With Next Steps"
+    },
+    {
+      name: "Welcome Package"
+    },
+    {
+      name: "Kick-Off Meeting, Team Introduction, Goal-Setting"
+    },
+    {
+      name: "Account Health Check"
+    },
+    {
+      name: "Monthly Status Report and Budget Updates",
+      recursIn: 30
+    },
+    {
+      name: "Weekly Communication Touchpoints",
+      recursIn: 7
+    },
+    {
+      name: "Monthly In-Person Meeting",
+      recursIn: 30
+    },
+    {
+      name: "Bi-Monthly Non-Business Function",
+      recursIn: 60
+    },
+    {
+      name: "Birthday Gift and Personalized Note",
+      recursIn: 365
+    },
+    {
+      name: "Monthly Article, Book, Tip or Recommendation",
+      recursIn: 30
+    }
+  ];
+  AV.Object.saveAll(
+    events.map(event =>
+      new AV.Object("Event")
+        .set("client", request.object)
+        .set("name", event.name)
+        .set("recursIn", event.recursIn)
+        .set(
+          "time",
+          new Date(
+            new Date(
+              new Date().setDate(new Date().getDate() + event.recursIn || 3)
+            ).setSeconds(0)
+          )
+        )
+    )
+  );
+});

--- a/cloud.js
+++ b/cloud.js
@@ -14,16 +14,20 @@ AV.Cloud.beforeSave("_User", request => {
 AV.Cloud.afterSave("Client", request => {
   const events = [
     {
-      name: "Welcome Email With Next Steps"
+      name: "Welcome Email With Next Steps",
+      delay: 1
     },
     {
-      name: "Welcome Package"
+      name: "Welcome Package",
+      delay: 2
     },
     {
-      name: "Kick-Off Meeting, Team Introduction, Goal-Setting"
+      name: "Kick-Off Meeting, Team Introduction, Goal-Setting",
+      delay: 3
     },
     {
-      name: "Account Health Check"
+      name: "Account Health Check",
+      delay: 90
     },
     {
       name: "Monthly Status Report and Budget Updates",
@@ -35,7 +39,8 @@ AV.Cloud.afterSave("Client", request => {
     },
     {
       name: "Monthly In-Person Meeting",
-      recursIn: 30
+      recursIn: 30,
+      delay: 5
     },
     {
       name: "Bi-Monthly Non-Business Function",
@@ -47,7 +52,8 @@ AV.Cloud.afterSave("Client", request => {
     },
     {
       name: "Monthly Article, Book, Tip or Recommendation",
-      recursIn: 30
+      recursIn: 30,
+      delay: 15
     }
   ];
   AV.Object.saveAll(
@@ -60,7 +66,11 @@ AV.Cloud.afterSave("Client", request => {
           "time",
           new Date(
             new Date(
-              new Date().setDate(new Date().getDate() + event.recursIn || 3)
+              new Date().setDate(
+                new Date().getDate() +
+                  (event.recursIn || 0) +
+                  (event.delay || 0)
+              )
             ).setSeconds(0)
           )
         )

--- a/src/App.vue
+++ b/src/App.vue
@@ -71,12 +71,6 @@ td {
   padding: 8px;
   width: 192px;
 }
-th.sortable {
-  cursor: pointer;
-}
-th.sortable > span > svg {
-  opacity: 0.4;
-}
 .card {
   position: relative;
   float: left;

--- a/src/App.vue
+++ b/src/App.vue
@@ -61,10 +61,10 @@ table {
   table-layout: fixed;
 }
 thead {
-  background-color: #00000009;
+  background-color: #00000008;
 }
 tbody {
-  background-color: #00000006;
+  background-color: #00000004;
 }
 th,
 td {

--- a/src/components/ClientCombo.vue
+++ b/src/components/ClientCombo.vue
@@ -1,0 +1,57 @@
+<template>
+  <span class="combo">
+    <img
+      :src="
+        client.get('picture')
+          ? client.get('picture').url()
+          : 'https://www.gravatar.com/avatar/00000000000000000000000000000000?d=mp&f=y'
+      "
+    />
+    <span>
+      <span>
+        <router-link :to="`/client/${client.id}`">
+          {{ client.get("fullName") }}
+        </router-link>
+        <a
+          v-if="client.get('linkedin')"
+          :href="`https://www.linkedin.com/in/${client.get('linkedin')}`"
+          target="_blank"
+        >
+          <font-awesome-icon :icon="['fab', 'linkedin']" />
+        </a>
+      </span>
+      <br />
+      <span class="nickname">
+        {{ client.get("nickname") }}
+      </span>
+    </span>
+  </span>
+</template>
+
+<script>
+import AV from "leancloud-storage";
+export default {
+  name: "ClientCombo",
+  props: {
+    client: AV.Object
+  }
+};
+</script>
+
+<style scoped>
+.combo {
+  display: flex;
+  align-items: center;
+}
+.combo > img {
+  margin: 0 1rem 0 0;
+  border-radius: 50%;
+  width: 30pt;
+  height: 30pt;
+  object-fit: cover;
+}
+.nickname {
+  font-size: 9pt;
+  opacity: 0.6;
+}
+</style>

--- a/src/components/ClientEvents.vue
+++ b/src/components/ClientEvents.vue
@@ -1,12 +1,160 @@
 <template>
   <section class="fields">
-    <h1>Events</h1>
+    <h1>Upcoming</h1>
+    <div class="field field--superwide">
+      <EventsTable :events="upcomingEvents" :fetch-events="fetchEvents" />
+    </div>
+    <h1>Suggested</h1>
+    <div class="field field--superwide">
+      <EventsTable :events="suggestedEvents" :fetch-events="fetchEvents" />
+    </div>
+    <h1>Past</h1>
+    <div class="field field--superwide">
+      <EventsTable :events="pastEvents" :fetch-events="fetchEvents" />
+    </div>
   </section>
 </template>
 
 <script>
+import EventsTable from "@/components/EventsTable.vue";
+import AV from "leancloud-storage";
 export default {
-  name: "ClientEvents"
+  name: "ClientEvents",
+  components: {
+    EventsTable
+  },
+  data() {
+    return {
+      upcomingEvents: [],
+      suggestedEvents: [],
+      pastEvents: []
+    };
+  },
+  created() {
+    const vm = this;
+    vm.fetchEvents();
+  },
+  methods: {
+    fetchEvents() {
+      const vm = this;
+      const upcomingEventQuery = new AV.Query("Event");
+      upcomingEventQuery
+        .equalTo(
+          "client",
+          AV.Object.createWithoutData("Client", vm.$route.params.id)
+        )
+        .equalTo("done", false)
+        .include("client")
+        .limit(1000)
+        .find()
+        .then(upcomingEvents => {
+          vm.upcomingEvents = upcomingEvents.map(event => ({
+            event,
+            editing: false,
+            pendingChanges: {
+              date: `${event.get("time").getFullYear()}-${`0${event
+                .get("time")
+                .getMonth() + 1}`.slice(-2)}-${`0${event
+                .get("time")
+                .getDate()}`.slice(-2)}`,
+              time: `${`0${event.get("time").getHours()}`.slice(
+                -2
+              )}:${`0${event.get("time").getMinutes()}`.slice(-2)}`
+            }
+          }));
+        })
+        .catch(error => {
+          alert(error);
+        });
+      const lastEventQuery = new AV.Query("Event");
+      lastEventQuery
+        .equalTo(
+          "client",
+          AV.Object.createWithoutData("Client", vm.$route.params.id)
+        )
+        .equalTo("done", true)
+        .exists("recursIn")
+        .include("client")
+        .limit(1000)
+        .find()
+        .then(lastEvents => {
+          vm.suggestedEvents = lastEvents.map(lastEvent => {
+            const rawTime = new Date(
+              new Date(lastEvent.get("time")).setDate(
+                lastEvent.get("time").getDate() + lastEvent.get("recursIn")
+              )
+            );
+            return {
+              event: new AV.Object("Event")
+                .set("name", lastEvent.get("name"))
+                .set("client", lastEvent.get("client"))
+                .set("recursIn", lastEvent.get("recursIn")),
+              editing: true,
+              pendingChanges: {
+                date: `${rawTime.getFullYear()}-${`0${rawTime.getMonth() +
+                  1}`.slice(-2)}-${`0${rawTime.getDate()}`.slice(-2)}`,
+                time: `${`0${rawTime.getHours()}`.slice(
+                  -2
+                )}:${`0${rawTime.getMinutes()}`.slice(-2)}`
+              },
+              lastEvent
+            };
+          });
+        })
+        .catch(error => {
+          alert(error);
+        });
+      const pastEventQuery = new AV.Query("Event");
+      pastEventQuery
+        .equalTo(
+          "client",
+          AV.Object.createWithoutData("Client", vm.$route.params.id)
+        )
+        .equalTo("done", true)
+        .include("client")
+        .limit(1000)
+        .find()
+        .then(pastEvents => {
+          vm.pastEvents = pastEvents.map(event => ({
+            event,
+            editing: false,
+            pendingChanges: {
+              date: `${event.get("time").getFullYear()}-${`0${event
+                .get("time")
+                .getMonth() + 1}`.slice(-2)}-${`0${event
+                .get("time")
+                .getDate()}`.slice(-2)}`,
+              time: `${`0${event.get("time").getHours()}`.slice(
+                -2
+              )}:${`0${event.get("time").getMinutes()}`.slice(-2)}`
+            }
+          }));
+        })
+        .catch(error => {
+          alert(error);
+        });
+    },
+    add(event) {
+      const vm = this;
+      event.event.set(
+        "time",
+        new Date(
+          event.pendingChanges.date.slice(0, 4),
+          event.pendingChanges.date.slice(5, 7) - 1,
+          event.pendingChanges.date.slice(8, 10),
+          event.pendingChanges.time.slice(0, 2),
+          event.pendingChanges.time.slice(3, 5),
+          0
+        )
+      );
+      event.lastEvent.unset("recursIn");
+      AV.Object.saveAll([event.event, event.lastEvent])
+        .then(vm.fetchEvents)
+        .catch(error => {
+          alert(error);
+        });
+    }
+  }
 };
 </script>
 

--- a/src/components/ClientFiles.vue
+++ b/src/components/ClientFiles.vue
@@ -75,7 +75,17 @@
                 {{ file.metaData("description") }}
               </span>
             </td>
-            <td>{{ file.createdAt.toLocaleString("en-US") }}</td>
+            <td>
+              {{
+                file.createdAt.toLocaleString("en-US", {
+                  year: "numeric",
+                  month: "numeric",
+                  day: "numeric",
+                  hour: "numeric",
+                  minute: "numeric"
+                })
+              }}
+            </td>
             <td>{{ addUnitToSize(file.size()) }}</td>
             <td>
               <button class="danger" @click="deleteFile(file)">Delete</button>

--- a/src/components/ClientsTable.vue
+++ b/src/components/ClientsTable.vue
@@ -2,95 +2,53 @@
   <table>
     <thead>
       <tr>
-        <th class="sortable" @click="sortBy('fullName')">
+        <ThWithSort
+          by="fullName"
+          :sorted-by="sortedBy"
+          :sort-order="sortOrder"
+          :sort-by="sortBy"
+        >
           Name
-          <span v-if="sortedBy === 'fullName'">
-            <font-awesome-icon
-              :icon="[
-                'fas',
-                sortOrder === 1 ? 'long-arrow-alt-up' : 'long-arrow-alt-down'
-              ]"
-            />
-          </span>
-        </th>
-        <th v-if="showCompany" class="sortable" @click="sortBy('company')">
+        </ThWithSort>
+        <ThWithSort
+          v-if="showCompany"
+          by="company"
+          :sorted-by="sortedBy"
+          :sort-order="sortOrder"
+          :sort-by="sortBy"
+        >
           Company
-          <span v-if="sortedBy === 'company'">
-            <font-awesome-icon
-              :icon="[
-                'fas',
-                sortOrder === 1 ? 'long-arrow-alt-up' : 'long-arrow-alt-down'
-              ]"
-            />
-          </span>
-        </th>
-        <th class="sortable" @click="sortBy('jobTitle')">
+        </ThWithSort>
+        <ThWithSort
+          by="jobTitle"
+          :sorted-by="sortedBy"
+          :sort-order="sortOrder"
+          :sort-by="sortBy"
+        >
           Job Title
-          <span v-if="sortedBy === 'jobTitle'">
-            <font-awesome-icon
-              :icon="[
-                'fas',
-                sortOrder === 1 ? 'long-arrow-alt-up' : 'long-arrow-alt-down'
-              ]"
-            />
-          </span>
-        </th>
-        <th class="sortable" @click="sortBy('email')">
+        </ThWithSort>
+        <ThWithSort
+          by="email"
+          :sorted-by="sortedBy"
+          :sort-order="sortOrder"
+          :sort-by="sortBy"
+        >
           Email
-          <span v-if="sortedBy === 'email'">
-            <font-awesome-icon
-              :icon="[
-                'fas',
-                sortOrder === 1 ? 'long-arrow-alt-up' : 'long-arrow-alt-down'
-              ]"
-            />
-          </span>
-        </th>
-        <th class="sortable" @click="sortBy('cellPhone')">
+        </ThWithSort>
+        <ThWithSort
+          by="cellPhone"
+          :sorted-by="sortedBy"
+          :sort-order="sortOrder"
+          :sort-by="sortBy"
+        >
           Cell Phone
-          <span v-if="sortedBy === 'cellPhone'">
-            <font-awesome-icon
-              :icon="[
-                'fas',
-                sortOrder === 1 ? 'long-arrow-alt-up' : 'long-arrow-alt-down'
-              ]"
-            />
-          </span>
-        </th>
+        </ThWithSort>
       </tr>
     </thead>
     <tbody>
       <tr v-for="client in sortedClients" :key="client.id">
         <td>
-          <span class="picture-name-combo">
-            <img
-              :src="
-                client.get('picture')
-                  ? client.get('picture').url()
-                  : 'https://www.gravatar.com/avatar/00000000000000000000000000000000?d=mp&f=y'
-              "
-            />
-            <span>
-              <span>
-                <router-link :to="`/client/${client.id}`">
-                  {{ client.get("fullName") }}
-                </router-link>
-                <a
-                  v-if="client.get('linkedin')"
-                  :href="
-                    `https://www.linkedin.com/in/${client.get('linkedin')}`
-                  "
-                  target="_blank"
-                >
-                  <font-awesome-icon :icon="['fab', 'linkedin']" />
-                </a>
-              </span>
-              <br />
-              <span class="nickname">
-                {{ client.get("nickname") }}
-              </span>
-            </span>
-          </span>
+          <ClientCombo :client="client" />
         </td>
         <td v-if="showCompany">
           <router-link :to="`/company/${client.get('company').id}`">
@@ -114,8 +72,14 @@
 </template>
 
 <script>
+import ThWithSort from "@/components/ThWithSort.vue";
+import ClientCombo from "@/components/ClientCombo.vue";
 export default {
   name: "ClientsTable",
+  components: {
+    ThWithSort,
+    ClientCombo
+  },
   props: {
     clients: Array,
     showCompany: Boolean
@@ -152,20 +116,4 @@ export default {
 };
 </script>
 
-<style scoped>
-.picture-name-combo {
-  display: flex;
-  align-items: center;
-}
-.picture-name-combo > img {
-  margin: 0 1rem 0 0;
-  border-radius: 50%;
-  width: 30pt;
-  height: 30pt;
-  object-fit: cover;
-}
-.nickname {
-  font-size: 9pt;
-  opacity: 0.6;
-}
-</style>
+<style scoped></style>

--- a/src/components/EventsTable.vue
+++ b/src/components/EventsTable.vue
@@ -2,79 +2,40 @@
   <table>
     <thead>
       <tr>
-        <th v-if="showClient" class="sortable" @click="sortBy('client')">
+        <ThWithSort
+          v-if="showClient"
+          by="client"
+          :sorted-by="sortedBy"
+          :sort-order="sortOrder"
+          :sort-by="sortBy"
+        >
           Client
-          <span v-if="sortedBy === 'client'">
-            <font-awesome-icon
-              :icon="[
-                'fas',
-                sortOrder === 1 ? 'long-arrow-alt-up' : 'long-arrow-alt-down'
-              ]"
-            />
-          </span>
-        </th>
-        <th class="sortable" @click="sortBy('name')">
+        </ThWithSort>
+        <ThWithSort
+          v-if="showClient"
+          by="name"
+          :sorted-by="sortedBy"
+          :sort-order="sortOrder"
+          :sort-by="sortBy"
+        >
           Event
-          <span v-if="sortedBy === 'name'">
-            <font-awesome-icon
-              :icon="[
-                'fas',
-                sortOrder === 1 ? 'long-arrow-alt-up' : 'long-arrow-alt-down'
-              ]"
-            />
-          </span>
-        </th>
-        <th class="sortable" @click="sortBy('time')">
+        </ThWithSort>
+        <ThWithSort
+          v-if="showClient"
+          by="time"
+          :sorted-by="sortedBy"
+          :sort-order="sortOrder"
+          :sort-by="sortBy"
+        >
           Time
-          <span v-if="sortedBy === 'time'">
-            <font-awesome-icon
-              :icon="[
-                'fas',
-                sortOrder === 1 ? 'long-arrow-alt-up' : 'long-arrow-alt-down'
-              ]"
-            />
-          </span>
-        </th>
+        </ThWithSort>
         <th>Option</th>
       </tr>
     </thead>
     <tbody>
       <tr v-for="event in sortedEvents" :key="event.event.id">
         <td v-if="showClient">
-          <span class="picture-name-combo">
-            <img
-              :src="
-                event.event.get('client').get('picture')
-                  ? event.event
-                      .get('client')
-                      .get('picture')
-                      .url()
-                  : 'https://www.gravatar.com/avatar/00000000000000000000000000000000?d=mp&f=y'
-              "
-            />
-            <span>
-              <span>
-                <router-link :to="`/client/${event.event.get('client').id}`">
-                  {{ event.event.get("client").get("fullName") }}
-                </router-link>
-                <a
-                  v-if="event.event.get('client').get('linkedin')"
-                  :href="
-                    `https://www.linkedin.com/in/${event.event
-                      .get('client')
-                      .get('linkedin')}`
-                  "
-                  target="_blank"
-                >
-                  <font-awesome-icon :icon="['fab', 'linkedin']" />
-                </a>
-              </span>
-              <br />
-              <span class="nickname">
-                {{ event.event.get("client").get("nickname") }}
-              </span>
-            </span>
-          </span>
+          <ClientCombo :client="event.event.get('client')" />
         </td>
         <td>{{ event.event.get("name") }}</td>
         <td>
@@ -123,9 +84,15 @@
 </template>
 
 <script>
+import ThWithSort from "@/components/ThWithSort.vue";
+import ClientCombo from "@/components/ClientCombo.vue";
 import AV from "leancloud-storage";
 export default {
   name: "EventsTable",
+  components: {
+    ThWithSort,
+    ClientCombo
+  },
   props: {
     events: Array,
     showClient: Boolean,
@@ -198,20 +165,4 @@ export default {
 };
 </script>
 
-<style scoped>
-.picture-name-combo {
-  display: flex;
-  align-items: center;
-}
-.picture-name-combo > img {
-  margin: 0 1rem 0 0;
-  border-radius: 50%;
-  width: 30pt;
-  height: 30pt;
-  object-fit: cover;
-}
-.nickname {
-  font-size: 9pt;
-  opacity: 0.6;
-}
-</style>
+<style scoped></style>

--- a/src/components/EventsTable.vue
+++ b/src/components/EventsTable.vue
@@ -12,7 +12,6 @@
           Client
         </ThWithSort>
         <ThWithSort
-          v-if="showClient"
           by="name"
           :sorted-by="sortedBy"
           :sort-order="sortOrder"
@@ -21,7 +20,6 @@
           Event
         </ThWithSort>
         <ThWithSort
-          v-if="showClient"
           by="time"
           :sorted-by="sortedBy"
           :sort-order="sortOrder"

--- a/src/components/EventsTable.vue
+++ b/src/components/EventsTable.vue
@@ -1,0 +1,217 @@
+<template>
+  <table>
+    <thead>
+      <tr>
+        <th v-if="showClient" class="sortable" @click="sortBy('client')">
+          Client
+          <span v-if="sortedBy === 'client'">
+            <font-awesome-icon
+              :icon="[
+                'fas',
+                sortOrder === 1 ? 'long-arrow-alt-up' : 'long-arrow-alt-down'
+              ]"
+            />
+          </span>
+        </th>
+        <th class="sortable" @click="sortBy('name')">
+          Event
+          <span v-if="sortedBy === 'name'">
+            <font-awesome-icon
+              :icon="[
+                'fas',
+                sortOrder === 1 ? 'long-arrow-alt-up' : 'long-arrow-alt-down'
+              ]"
+            />
+          </span>
+        </th>
+        <th class="sortable" @click="sortBy('time')">
+          Time
+          <span v-if="sortedBy === 'time'">
+            <font-awesome-icon
+              :icon="[
+                'fas',
+                sortOrder === 1 ? 'long-arrow-alt-up' : 'long-arrow-alt-down'
+              ]"
+            />
+          </span>
+        </th>
+        <th>Option</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr v-for="event in sortedEvents" :key="event.event.id">
+        <td v-if="showClient">
+          <span class="picture-name-combo">
+            <img
+              :src="
+                event.event.get('client').get('picture')
+                  ? event.event
+                      .get('client')
+                      .get('picture')
+                      .url()
+                  : 'https://www.gravatar.com/avatar/00000000000000000000000000000000?d=mp&f=y'
+              "
+            />
+            <span>
+              <span>
+                <router-link :to="`/client/${event.event.get('client').id}`">
+                  {{ event.event.get("client").get("fullName") }}
+                </router-link>
+                <a
+                  v-if="event.event.get('client').get('linkedin')"
+                  :href="
+                    `https://www.linkedin.com/in/${event.event
+                      .get('client')
+                      .get('linkedin')}`
+                  "
+                  target="_blank"
+                >
+                  <font-awesome-icon :icon="['fab', 'linkedin']" />
+                </a>
+              </span>
+              <br />
+              <span class="nickname">
+                {{ event.event.get("client").get("nickname") }}
+              </span>
+            </span>
+          </span>
+        </td>
+        <td>{{ event.event.get("name") }}</td>
+        <td>
+          <form v-if="event.editing" @submit.prevent="update(event)">
+            <div class="field">
+              <input
+                type="date"
+                max="2099-12-31"
+                v-model="event.pendingChanges.date"
+                required
+              />
+            </div>
+            <div class="field">
+              <input type="time" v-model="event.pendingChanges.time" required />
+            </div>
+            <div class="field">
+              <button class="primary">
+                Save
+              </button>
+            </div>
+          </form>
+          <a v-else @click="event.editing = true">
+            {{
+              event.event.get("time").toLocaleString("en-US", {
+                year: "numeric",
+                month: "numeric",
+                day: "numeric",
+                hour: "numeric",
+                minute: "numeric"
+              })
+            }}
+          </a>
+        </td>
+        <td>
+          <button
+            v-if="!event.editing"
+            :class="[event.event.get('done') ? '' : 'primary']"
+            @click="toggle(event)"
+          >
+            {{ event.event.get("done") ? "Undone" : "Done" }}
+          </button>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</template>
+
+<script>
+import AV from "leancloud-storage";
+export default {
+  name: "EventsTable",
+  props: {
+    events: Array,
+    showClient: Boolean,
+    fetchEvents: Function
+  },
+  data() {
+    return {
+      sortedBy: "time",
+      sortOrder: 1
+    };
+  },
+  methods: {
+    sortBy(field) {
+      const vm = this;
+      vm.sortOrder = vm.sortedBy === field ? -vm.sortOrder : 1;
+      vm.sortedBy = field;
+    },
+    update(event) {
+      const vm = this;
+      event.event.set(
+        "time",
+        new Date(
+          event.pendingChanges.date.slice(0, 4),
+          event.pendingChanges.date.slice(5, 7) - 1,
+          event.pendingChanges.date.slice(8, 10),
+          event.pendingChanges.time.slice(0, 2),
+          event.pendingChanges.time.slice(3, 5),
+          0
+        )
+      );
+      if (event.lastEvent) {
+        event.lastEvent.unset("recursIn");
+        AV.Object.saveAll([event.event, event.lastEvent])
+          .then(vm.fetchEvents)
+          .catch(error => {
+            alert(error);
+          });
+      } else {
+        event.event
+          .save()
+          .then(() => {
+            event.editing = false;
+          })
+          .catch(error => {
+            alert(error);
+          });
+      }
+    },
+    toggle(event) {
+      const vm = this;
+      event.event
+        .set("done", !event.event.get("done"))
+        .save()
+        .then(vm.fetchEvents)
+        .catch(error => {
+          alert(error);
+        });
+    }
+  },
+  computed: {
+    sortedEvents() {
+      const vm = this;
+      return vm.events.sort((a, b) =>
+        a.event.get(vm.sortedBy) > b.event.get(vm.sortedBy)
+          ? vm.sortOrder
+          : -vm.sortOrder
+      );
+    }
+  }
+};
+</script>
+
+<style scoped>
+.picture-name-combo {
+  display: flex;
+  align-items: center;
+}
+.picture-name-combo > img {
+  margin: 0 1rem 0 0;
+  border-radius: 50%;
+  width: 30pt;
+  height: 30pt;
+  object-fit: cover;
+}
+.nickname {
+  font-size: 9pt;
+  opacity: 0.6;
+}
+</style>

--- a/src/components/ThWithSort.vue
+++ b/src/components/ThWithSort.vue
@@ -1,0 +1,34 @@
+<template>
+  <th @click="sortBy(by)">
+    <slot></slot>
+    <span v-if="by === sortedBy">
+      <font-awesome-icon
+        :icon="[
+          'fas',
+          sortOrder === 1 ? 'long-arrow-alt-up' : 'long-arrow-alt-down'
+        ]"
+      />
+    </span>
+  </th>
+</template>
+
+<script>
+export default {
+  name: "ThWithSort",
+  props: {
+    by: String,
+    sortedBy: String,
+    sortOrder: Number,
+    sortBy: Function
+  }
+};
+</script>
+
+<style scoped>
+th {
+  cursor: pointer;
+}
+th > span > svg {
+  opacity: 0.4;
+}
+</style>

--- a/src/views/NotesPage.vue
+++ b/src/views/NotesPage.vue
@@ -43,7 +43,15 @@
           <div v-if="!note.editing" class="field">
             <h1>{{ note.note.get("title") }}</h1>
             <p class="time">
-              {{ note.note.createdAt.toLocaleString("en-US") }}
+              {{
+                note.note.createdAt.toLocaleString("en-US", {
+                  year: "numeric",
+                  month: "numeric",
+                  day: "numeric",
+                  hour: "numeric",
+                  minute: "numeric"
+                })
+              }}
             </p>
             <p>{{ note.note.get("content") }}</p>
             <p>

--- a/src/views/OverviewPage.vue
+++ b/src/views/OverviewPage.vue
@@ -3,45 +3,178 @@
     <div class="column column--right">
       <div class="card">
         <section class="fields">
-          <h1>Overview</h1>
-          <div class="field">
-            <p>
-              This is the overview page that shows upcoming events.
-            </p>
-          </div>
+          <h1>Suggestions</h1>
+          <p v-if="suggestedEvents.length">
+            {{ suggestedEvents.length }}
+            {{ suggestedEvents.length === 1 ? "event" : "events" }} can be
+            scheduled.
+          </p>
+          <p v-else>You are all caught up!</p>
+        </section>
+        <section
+          v-for="event in suggestedEvents"
+          :key="event.event.id"
+          class="fields"
+        >
+          <p>
+            {{ event.event.get("name") }} with
+            {{ event.event.get("client").get("fullName") }}
+          </p>
+          <form @submit.prevent="add(event)">
+            <div class="field">
+              <input
+                type="date"
+                max="2099-12-31"
+                v-model="event.nextTime.date"
+                required
+              />
+            </div>
+            <div class="field">
+              <input type="time" v-model="event.nextTime.time" required />
+            </div>
+            <div class="field">
+              <button class="primary">
+                Add
+              </button>
+            </div>
+          </form>
         </section>
       </div>
     </div>
     <div class="column column--left">
       <div class="card">
         <section class="fields">
-          <h1>UI Demo</h1>
-          <div class="field field--half">
-            <label>
-              Text Input
-              <input type="text" />
-            </label>
-          </div>
-          <div class="field field--half">
-            <label>
-              Dropdown
-              <select>
-                <option>Option 1</option>
-                <option>Option 2</option>
-              </select>
-            </label>
-          </div>
+          <h1>Upcoming</h1>
           <div class="field">
-            <label>
-              Text Area
-              <textarea />
-            </label>
-          </div>
-          <div class="field">
-            <button class="primary">Primary Button</button>
-          </div>
-          <div class="field">
-            <button>Secondary Button</button>
+            <table>
+              <thead>
+                <tr>
+                  <th class="sortable" @click="sortBy('client')">
+                    Client
+                    <span v-if="sortedBy === 'client'">
+                      <font-awesome-icon
+                        :icon="[
+                          'fas',
+                          sortOrder === 1
+                            ? 'long-arrow-alt-up'
+                            : 'long-arrow-alt-down'
+                        ]"
+                      />
+                    </span>
+                  </th>
+                  <th class="sortable" @click="sortBy('name')">
+                    Event
+                    <span v-if="sortedBy === 'name'">
+                      <font-awesome-icon
+                        :icon="[
+                          'fas',
+                          sortOrder === 1
+                            ? 'long-arrow-alt-up'
+                            : 'long-arrow-alt-down'
+                        ]"
+                      />
+                    </span>
+                  </th>
+                  <th class="sortable" @click="sortBy('time')">
+                    Time
+                    <span v-if="sortedBy === 'time'">
+                      <font-awesome-icon
+                        :icon="[
+                          'fas',
+                          sortOrder === 1
+                            ? 'long-arrow-alt-up'
+                            : 'long-arrow-alt-down'
+                        ]"
+                      />
+                    </span>
+                  </th>
+                  <th>Done</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="event in sortedUpcomingEvents" :key="event.event.id">
+                  <td>
+                    <span class="picture-name-combo">
+                      <img
+                        :src="
+                          event.event.get('client').get('picture')
+                            ? event.event
+                                .get('client')
+                                .get('picture')
+                                .url()
+                            : 'https://www.gravatar.com/avatar/00000000000000000000000000000000?d=mp&f=y'
+                        "
+                      />
+                      <span>
+                        <span>
+                          <router-link
+                            :to="`/client/${event.event.get('client').id}`"
+                          >
+                            {{ event.event.get("client").get("fullName") }}
+                          </router-link>
+                          <a
+                            v-if="event.event.get('client').get('linkedin')"
+                            :href="
+                              `https://www.linkedin.com/in/${event.event
+                                .get('client')
+                                .get('linkedin')}`
+                            "
+                            target="_blank"
+                          >
+                            <font-awesome-icon :icon="['fab', 'linkedin']" />
+                          </a>
+                        </span>
+                        <br />
+                        <span class="nickname">
+                          {{ event.event.get("client").get("nickname") }}
+                        </span>
+                      </span>
+                    </span>
+                  </td>
+                  <td>{{ event.event.get("name") }}</td>
+                  <td>
+                    <form v-if="event.editing" @submit.prevent="update(event)">
+                      <div class="field">
+                        <input
+                          type="date"
+                          max="2099-12-31"
+                          v-model="event.pendingChanges.date"
+                          required
+                        />
+                      </div>
+                      <div class="field">
+                        <input
+                          type="time"
+                          v-model="event.pendingChanges.time"
+                          required
+                        />
+                      </div>
+                      <div class="field">
+                        <button class="primary">
+                          Save
+                        </button>
+                      </div>
+                    </form>
+                    <a v-else @click="event.editing = true">
+                      {{
+                        event.event.get("time").toLocaleString("en-US", {
+                          year: "numeric",
+                          month: "numeric",
+                          day: "numeric",
+                          hour: "numeric",
+                          minute: "numeric"
+                        })
+                      }}
+                    </a>
+                  </td>
+                  <td>
+                    <button class="primary" @click="done(event)">
+                      Done
+                    </button>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
           </div>
         </section>
       </div>
@@ -50,9 +183,169 @@
 </template>
 
 <script>
+import AV from "leancloud-storage";
 export default {
-  name: "OverviewPage"
+  name: "OverviewPage",
+  data() {
+    return {
+      upcomingEvents: [],
+      suggestedEvents: [],
+      sortedBy: "time",
+      sortOrder: 1
+    };
+  },
+  created() {
+    const vm = this;
+    vm.fetchEvents();
+  },
+  methods: {
+    fetchEvents() {
+      const vm = this;
+      const upcomingEventQuery = new AV.Query("Event");
+      upcomingEventQuery
+        .equalTo("done", false)
+        .include("client")
+        .limit(1000)
+        .find()
+        .then(upcomingEvents => {
+          vm.upcomingEvents = upcomingEvents.map(event => ({
+            event,
+            editing: false,
+            pendingChanges: {
+              date: `${event.get("time").getFullYear()}-${`0${event
+                .get("time")
+                .getMonth() + 1}`.slice(-2)}-${`0${event
+                .get("time")
+                .getDate()}`.slice(-2)}`,
+              time: `${`0${event.get("time").getHours()}`.slice(
+                -2
+              )}:${`0${event.get("time").getMinutes()}`.slice(-2)}`
+            }
+          }));
+        })
+        .catch(error => {
+          alert(error);
+        });
+      const suggestedEventQuery = new AV.Query("Event");
+      suggestedEventQuery
+        .equalTo("done", true)
+        .exists("recursIn")
+        .include("client")
+        .ascending("time")
+        .limit(1000)
+        .find()
+        .then(suggestedEvents => {
+          vm.suggestedEvents = suggestedEvents.map(event => {
+            const rawNextTime = new Date(
+              event
+                .get("time")
+                .setDate(event.get("time").getDate() + event.get("recursIn"))
+            );
+            return {
+              event,
+              nextTime: {
+                date: `${rawNextTime.getFullYear()}-${`0${rawNextTime.getMonth() +
+                  1}`.slice(-2)}-${`0${rawNextTime.getDate()}`.slice(-2)}`,
+                time: `${`0${rawNextTime.getHours()}`.slice(
+                  -2
+                )}:${`0${rawNextTime.getMinutes()}`.slice(-2)}`
+              }
+            };
+          });
+        })
+        .catch(error => {
+          alert(error);
+        });
+    },
+    add(lastEvent) {
+      const vm = this;
+      const event = new AV.Object("Event");
+      event
+        .set("name", lastEvent.event.get("name"))
+        .set("client", lastEvent.event.get("client"))
+        .set("recursIn", lastEvent.event.get("recursIn"))
+        .set(
+          "time",
+          new Date(
+            lastEvent.nextTime.date.slice(0, 4),
+            lastEvent.nextTime.date.slice(5, 7) - 1,
+            lastEvent.nextTime.date.slice(8, 10),
+            lastEvent.nextTime.time.slice(0, 2),
+            lastEvent.nextTime.time.slice(3, 5),
+            0
+          )
+        );
+      lastEvent.event.unset("recursIn");
+      AV.Object.saveAll([event, lastEvent.event])
+        .then(vm.fetchEvents)
+        .catch(error => {
+          alert(error);
+        });
+    },
+    sortBy(field) {
+      const vm = this;
+      vm.sortOrder = vm.sortedBy === field ? -vm.sortOrder : 1;
+      vm.sortedBy = field;
+    },
+    update(event) {
+      event.event
+        .set(
+          "time",
+          new Date(
+            event.pendingChanges.date.slice(0, 4),
+            event.pendingChanges.date.slice(5, 7) - 1,
+            event.pendingChanges.date.slice(8, 10),
+            event.pendingChanges.time.slice(0, 2),
+            event.pendingChanges.time.slice(3, 5),
+            0
+          )
+        )
+        .save()
+        .then(() => {
+          event.editing = false;
+        })
+        .catch(error => {
+          alert(error);
+        });
+    },
+    done(event) {
+      const vm = this;
+      event.event
+        .set("done", true)
+        .save()
+        .then(vm.fetchEvents)
+        .catch(error => {
+          alert(error);
+        });
+    }
+  },
+  computed: {
+    sortedUpcomingEvents() {
+      const vm = this;
+      return vm.upcomingEvents.sort((a, b) =>
+        a.event.get(vm.sortedBy) > b.event.get(vm.sortedBy)
+          ? vm.sortOrder
+          : -vm.sortOrder
+      );
+    }
+  }
 };
 </script>
 
-<style scoped></style>
+<style scoped>
+.picture-name-combo {
+  display: flex;
+  align-items: center;
+}
+.picture-name-combo > img {
+  margin: 0 1rem 0 0;
+  border-radius: 50%;
+  width: 30pt;
+  height: 30pt;
+  object-fit: cover;
+}
+.nickname {
+  font-size: 9pt;
+  opacity: 0.6;
+}
+</style>


### PR DESCRIPTION
Upcoming confirmed events and suggested events are now displayed on the "Overview" page. On the "Client" page, both these two groups of events are displayed as well, together with past events. When a new client is created, all the "one-time events" and "recurring events" specified in `Spakset Client Peference Data  - 1.28.20.pdf` will be automatically created for this client. An event can be marked as done by clicking on the "Done" button for it. If it's a one-time event, the event will simply be dismissed. If it's a recurring event, a suggestion for scheduling the next occurrence will show up under "Suggestions" and clicking on the "Add" button will add the same event to the "Upcoming" list but with the time updated to be the next time it should occur.